### PR TITLE
factor out relative project path logic into a single method

### DIFF
--- a/lib/stash/client.rb
+++ b/lib/stash/client.rb
@@ -187,10 +187,6 @@ module Stash
       post "projects/#{project}/repos", opts
     end
 
-    def get_project_path(project)
-      "projects/#{project.fetch('key')}"
-    end
-
     private
 
     def fetch_all(uri, args = {})
@@ -245,6 +241,10 @@ module Stash
 
     def remove_leading_slash(str)
       str.sub(/\A\//, '')
+    end
+    
+    def get_project_path(project)
+      "projects/#{project.fetch('key')}"
     end
 
     def repo_path(repository)

--- a/lib/stash/client.rb
+++ b/lib/stash/client.rb
@@ -50,12 +50,12 @@ module Stash
     end
 
     def update_project(project, opts={})
-      project_path = project.fetch('links').fetch('self').first['href']
+      project_path = get_project_path(project)
       put project_path, opts
     end
 
     def delete_project(project)
-      project_path = project.fetch('links').fetch('self').first['href']
+      project_path = get_project_path(project)
       delete project_path
     end
 
@@ -67,7 +67,7 @@ module Stash
     end
 
     def repositories_for(project)
-      project_path = project.fetch('links').fetch('self').first['href'] + '/repos'
+      project_path = get_project_path(project) + '/repos'
       repos = fetch_all project_path
       repos.flatten
     end
@@ -185,6 +185,10 @@ module Stash
 
     def create_repo(project, opts={})
       post "projects/#{project}/repos", opts
+    end
+
+    def get_project_path(project)
+      "projects/#{project.fetch('key')}"
     end
 
     private


### PR DESCRIPTION
Fixed the project path to be a relative value instead of fetching href which is the entire URL. Moved that code into a method. Still need to update `repo_path` logic to account for this change, but `project_path` works and ready for merge. 
