### PR TITLE
fix prefix in repo_path value

### DIFF
--- a/lib/stash/client.rb
+++ b/lib/stash/client.rb
@@ -248,7 +248,7 @@ module Stash
     end
 
     def repo_path(repository)
-      relative_project_path = repository.fetch('project').fetch('key')
+      relative_project_path = 'projects/' + repository.fetch('project').fetch('key')
       relative_project_path + '/repos/' + repository.fetch('slug')
     end
   end


### PR DESCRIPTION
Adding `projects/` prefix to repo_path returned value
